### PR TITLE
#22 Data structure rework

### DIFF
--- a/core/data/command.py
+++ b/core/data/command.py
@@ -47,7 +47,7 @@ class Command:
             "time_executed": str(self.time_executed),
             "device_id": str(self.device_id),
             "response": str(self.response),
-            "target": str(self.args),
+            "arguments": str(self.args),
             "source": str(self.source),
             "command_id": str(self.command_id)
         }

--- a/core/data/dao.py
+++ b/core/data/dao.py
@@ -21,7 +21,7 @@ class Dao:
             "time_issued",
             "device_id",
             "command_id",
-            "target",
+            "arguments",
             "response",
             "time_executed",
             "source",
@@ -49,7 +49,7 @@ class Dao:
                  "time_issued VARCHAR(255),"
                  "device_id VARCHAR(255),"
                  "command_id VARCHAR(255),"
-                 "target VARCHAR(255),"
+                 "arguments VARCHAR(255),"
                  "response VARCHAR(1000),"
                  "time_executed VARCHAR(255),"
                  "source VARCHAR(255),"

--- a/core/data/manager.py
+++ b/core/data/manager.py
@@ -38,8 +38,7 @@ class DataManager:
 
         for row in response:
             log_id = row[0]
-            row = row[1:]
-            row = dict(zip(Dao.cmd_table_columns[1:], row))
+            row = dict(zip(Dao.cmd_table_columns[1:], row[1:]))
             result[log_id] = row
 
         if device_id is not None and response:

--- a/core/data/manager.py
+++ b/core/data/manager.py
@@ -37,8 +37,15 @@ class DataManager:
         columns.pop(0)
 
         for row in response:
-            log_id = row[0]
-            row = dict(zip(Dao.cmd_table_columns[1:], row[1:]))
+            log_id = int(row[0])
+            row = dict(zip(Dao.cmd_table_columns[1:], (row[1:])))
+            for key, item in row.items():
+                # noinspection PyBroadException
+                try:
+                    item = eval(item)
+                    row[key] = item
+                except Exception:
+                    continue
             result[log_id] = row
 
         if device_id is not None and response:

--- a/core/data/manager.py
+++ b/core/data/manager.py
@@ -18,7 +18,7 @@ class DataManager:
             ("time_executed", str(cmd.time_executed)),
             ("device_id", str(cmd.device_id)),
             ("response", str(cmd.response)),
-            ("target", str(cmd.args)),
+            ("arguments", str(cmd.args)),
             ("source", str(cmd.source)),
             ("command_id", str(cmd.command_id)),
             ("is_valid", int(cmd.is_valid))

--- a/core/data/manager.py
+++ b/core/data/manager.py
@@ -39,6 +39,7 @@ class DataManager:
         for row in response:
             log_id = row[0]
             row = row[1:]
+            row = dict(zip(Dao.cmd_table_columns[1:], row))
             result[log_id] = row
 
         if device_id is not None and response:

--- a/core/data/model.py
+++ b/core/data/model.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+from flask import jsonify
+
+
+class Response:
+    def __init__(self, success: bool, data: Optional[dict], cause: Optional[Exception] = None):
+        self.cause = cause
+        self.data = data
+        self.success = success
+
+    def to_json(self):
+        return jsonify(
+            {
+                "success": self.success,
+                "cause": self.cause,
+                "data": self.data,
+            }
+        )

--- a/core/manager.py
+++ b/core/manager.py
@@ -1,7 +1,6 @@
-from typing import Tuple, Optional
-
 from core.data.command import Command
 from core.data.manager import DataManager
+from core.data.model import Response
 from core.device.manager import DeviceManager
 from core.log import Log
 from core.task.manager import TaskManager
@@ -16,66 +15,66 @@ class AppManager:
         self.deviceManager: DeviceManager = deviceManager
         self.dataManager: DataManager = dataManager
 
-    def register_device(self, config: dict) -> (bool, Optional[Exception], None):
+    def register_device(self, config: dict) -> Response:
         try:
             device = self.deviceManager.new_device(config)
         except (IdError, ModuleNotFoundError, AttributeError) as e:
             Log.error(e)
-            return False, e, None
+            return Response(False, None, e)
 
-        return device is not None, None, None
+        return Response(device is not None, None)
 
-    def end_device(self, device_id: str):
+    def end_device(self, device_id: str) -> Response:
         try:
             self.deviceManager.remove_device(device_id)
-            return True, None, None
+            return Response(True, None)
         except AttributeError:
             exc = IdError("Connector with given ID: %s was not found" % device_id)
             Log.error(exc)
-            return False, exc, None
+            return Response(False, None, exc)
 
-    def command(self, device_id, command_id, args, source, priority=False):
+    def command(self, device_id, command_id, args, source, priority=False) -> Response:
         try:
             cmd = Command(device_id, command_id, eval(args), source)
             if priority:
                 self.deviceManager.get_device(device_id).post_command(cmd, priority=1)
             else:
                 self.deviceManager.get_device(device_id).post_command(cmd)
-            return True, None, None
+            return Response(True, None)
         except (IdError, AttributeError) as e:
             Log.error(e)
-            return False, e, None
+            return Response(False, None, e)
 
-    def register_task(self, config):
+    def register_task(self, config) -> Response:
         try:
             task = self.taskManager.create_task(config)
             task.start()
-            return True, None, None
+            return Response(True, None)
         except (IdError, TypeError) as e:
             Log.error(e)
-            return False, e, None
+            return Response(False, None, e)
 
-    def end_task(self, task_id):
+    def end_task(self, task_id) -> Response:
         try:
             self.taskManager.remove_task(task_id)
-            return True, None, None
+            return Response(True, None)
         except IdError as e:
             Log.error(e)
-            return False, e, None
+            return Response(False, None, e)
 
-    def ping(self) -> Tuple[bool, Optional[Exception], dict]:
-        return True, None, {
+    def ping(self) -> Response:
+        return Response(True, {
             "devices": self.deviceManager.ping(),
             "tasks": self.taskManager.ping()
-        }
+        })
 
-    def get_data(self, device_id, log_id=None, time=None):
-        return True, None, self.dataManager.get_data(log_id, time, device_id)
+    def get_data(self, device_id, log_id=None, time=None) -> Response:
+        return Response(True, self.dataManager.get_data(log_id, time, device_id))
 
-    def get_latest_data(self, device_id=None):
-        return True, None, self.dataManager.get_latest_data(device_id=device_id)
+    def get_latest_data(self, device_id=None) -> Response:
+        return Response(True, self.dataManager.get_latest_data(device_id=device_id))
 
-    def end(self):
+    def end(self) -> Response:
         self.deviceManager.end()
         self.taskManager.end()
-        return True, None, None
+        return Response(True, None)


### PR DESCRIPTION
References issue #22 

The proposed structure of data returned by the [get data endpoint](https://github.com/SmartBioTech/DeviceControl/wiki/Flask-Server-Module#get-data):

```
{
"success" : <boolean>,
"cause" : <null OR string (exception detail etc.)>,
"data" : {
   <string (Log ID of the entry)> : {
      'command_id': '12',    ### SHOULD BE AN INT OR A STRING?
      'device_id': '1',            ### INT OR STRING?
      'is_valid': 1, 
      'response': {'pwm_pulse': 1, 'pwm_min': 0, 'pwm_max': 100, 'pwm_on': True},        ### DICT OR STRING?
      'source': 'D1-measureall', 
      'target': '[]',        ### LIST OR STRING?
      'time_executed': '2020-05-15 00:51:26',
      'time_issued': '2020-05-15 00:51:26'
      }
   }
}
```

Please, note the dict/list/string/int questions. @xtrojak, what is the expected (preferred) approach? Currently, each field tries to eval itself => dicts, lists and integers are returned instead of strings where possible. The downside of this is that if one of the other fields (command_id, device_id) **MIGHT** be pythonically evaluated into integers from strings, which might not be expected behaviour.