### PR TITLE
device/task relationship reworked

### DIFF
--- a/core/connection/server/FlaskServer.py
+++ b/core/connection/server/FlaskServer.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from flask import Flask, request
 
 from core.data.manager import DataManager

--- a/core/device/abstract.py
+++ b/core/device/abstract.py
@@ -11,7 +11,6 @@ class Connector(metaclass=Interface):
 
     def __init__(self, config: dict):
         self.device_id = None
-        self.device_class = None
         self.address = None
         self.setup = {}
         self.scheduler = WorkflowProvider().scheduler
@@ -20,7 +19,6 @@ class Connector(metaclass=Interface):
 
         try:
             assert self.device_id is not None
-            assert self.device_class is not None
             assert self.address is not None
         except AssertionError:
             raise AttributeError("Invalid configuration")

--- a/core/device/manager.py
+++ b/core/device/manager.py
@@ -12,9 +12,11 @@ class DeviceManager:
         self._devices: Dict[str, Connector] = {}
 
     def new_device(self, config: dict) -> Connector:
+        device_class = config.get("device_class")
+        device_type = config.get("device_type")
         if self._devices.get(config.get("device_id")) is not None:
             raise IdError("Connector with given ID already exists")
-        device = self.load_class(config.get("device_class"))(config)
+        device = self.load_class(device_class, device_type)(config)
         self._devices[device.device_id] = device
         return device
 
@@ -41,6 +43,6 @@ class DeviceManager:
         return result
 
     @staticmethod
-    def load_class(class_id: str) -> Connector.__class__:
+    def load_class(device_class: str, device_type: str) -> Connector.__class__:
         from custom.devices import classes
-        return classes.get(class_id)
+        return classes.get(device_class, {}).get(device_type)

--- a/core/task/manager.py
+++ b/core/task/manager.py
@@ -13,20 +13,21 @@ class TaskManager:
 
     def create_task(self, config: dict):
         task_id = config.get("task_id")
-        task_class = config.get("task_class")
+        task_class = config.get('task_class')
+        task_type = config.get('task_type')
         assert task_id is not None
         assert task_class is not None
         if task_id not in self.tasks:
-            task = self.load_class(task_class)(config)
+            task = self.load_class(task_class, task_type)(config)
             self.tasks[task_id] = task
             return task
         else:
             raise IdError("Task with requested ID already exists")
 
     @staticmethod
-    def load_class(task_class: str) -> BaseTask.__class__:
+    def load_class(task_class: str, task_type: str) -> BaseTask.__class__:
         from custom.tasks import classes
-        return classes.get(task_class)
+        return classes.get(task_class, {}).get(task_type)
 
     def remove_task(self, task_id):
         if task_id in self.tasks:

--- a/custom/devices/__init__.py
+++ b/custom/devices/__init__.py
@@ -1,18 +1,31 @@
-from custom.devices.PSI import java, test
+from custom.devices import MettlerToledo
 from custom.devices import Phenometrics
 from custom.devices import SEDtronic
-from custom.devices import MettlerToledo
-
+from custom.devices.PSI import java, test
 
 classes = {
-    "MettlerToledo_SICS": MettlerToledo.SICS,
-    "UniPi_1WTHIB2" : SEDtronic.TH_IB2,
-    "SEDtronic_U1WTVSL" : SEDtronic.U1W_TVSL,
-    "Phenometrics_PBR": Phenometrics.PBR,
-    "PSI_java_PBR": java.PBR,
-    "PSI_java_GAS": java.GAS,
-    "PSI_java_GMS": java.GMS,
-    "test_PBR": test.PBR,
-    "test_GAS": test.GAS,
-    "test_GMS": test.GMS
+    "PSI": {
+        "PBR": java.PBR,
+        "GAS": java.GAS,
+        "GMS": java.GMS
+    },
+
+    "test": {
+        "PBR": test.PBR,
+        "GAS": test.GAS,
+        "GMS": test.GMS
+    },
+
+    "Phenometrics": {
+        "PBR": Phenometrics.PBR
+    },
+
+    "SEDtronic": {
+        "U1WTVSL": SEDtronic.U1W_TVSL,
+        "1WTHIB2": SEDtronic.TH_IB2
+    },
+
+    "MettlerToledo": {
+        "SICS": MettlerToledo.SICS
+    }
 }

--- a/custom/tasks/__init__.py
+++ b/custom/tasks/__init__.py
@@ -1,11 +1,24 @@
 from custom.tasks import PBR, GAS, GMS, TH_IB2, U1W_TVSL, SICS
 
 classes = {
-    "Balance_measure_weight": SICS.MeasureWeight,
-    "U1W_TVSL_measure_all": U1W_TVSL.MeasureAll,
-    "TH_IB2_measure_all": TH_IB2.MeasureAll,
-    "PBR_measure_all": PBR.PBRMeasureAll,
-    "PSI_PBR_pump": PBR.PBRGeneralPump,
-    "GAS_measure_all": GAS.GASMeasureAll,
-    "GMS_measure_all": GMS.GMSMeasureAll
+    "PSI": {
+        "PBR_measure_all": PBR.PBRMeasureAll,
+        "GAS_measure_all": GAS.GASMeasureAll,
+        "PBR_pump": PBR.PBRGeneralPump,
+        "GMS_measure_all": GMS.GMSMeasureAll
+    },
+
+    "MettlerToledo": {
+        "Balance_measure_weight": SICS.MeasureWeight
+    },
+
+    "SEDtronic": {
+        "U1W_TVSL_measure_all": U1W_TVSL.MeasureAll,
+        "TH_IB2_measure_all": TH_IB2.MeasureAll,
+    },
+
+    "General": {
+        "PBR_general_pump": PBR.PBRGeneralPump,
+
+    }
 }


### PR DESCRIPTION
Addresses #27 and #29 

Devices and Tasks are now separated into groups. The `task_class `and `device_class` fields in JSON requests each correspond to the group in which the given device/task is. Furthermore, in these groups, each device/task has an ID specific for the given type of device/task and which must be unique in its group.

Note: Since classes in python can't have an attribute named e.g. `self.class`, it was necessary for the json fields to be `task_class`, `task_type `and `device_class`, `device_type`. 

@JanCervenyy please check if the devices and tasks are appropriately named and grouped

EDIT: PR does not address #28 